### PR TITLE
Support additional features/functions

### DIFF
--- a/Import/ReportingServices/DataSources/DataSourceConverter.cs
+++ b/Import/ReportingServices/DataSources/DataSourceConverter.cs
@@ -315,10 +315,9 @@ namespace DevExpress.XtraReports.Import.ReportingServices.DataSources {
             if(query == null) {
                 var commandTypeEnum = (CommandType)Enum.Parse(typeof(CommandType), commandType);
                 var command = new SqlCommand() { CommandType = commandTypeEnum, CommandText = commandText };
-                query = DataSetToSqlDataSourceConverter.CreateSqlQuery(state.DataSetName, command);
-                if(query != null) {
-                    state.DataSource.Queries.Add(query);
-                }
+                SqlDataSource.DisableCustomQueryValidation = false;
+                query = new CustomSqlQuery(state.DataSetName, command.CommandText.Trim());
+                state.DataSource.Queries.Add(query);
             }
             return query;
         }

--- a/Import/ReportingServices/DataSources/DataSourceConverter.cs
+++ b/Import/ReportingServices/DataSources/DataSourceConverter.cs
@@ -315,7 +315,6 @@ namespace DevExpress.XtraReports.Import.ReportingServices.DataSources {
             if(query == null) {
                 var commandTypeEnum = (CommandType)Enum.Parse(typeof(CommandType), commandType);
                 var command = new SqlCommand() { CommandType = commandTypeEnum, CommandText = commandText };
-                SqlDataSource.DisableCustomQueryValidation = false;
                 query = new CustomSqlQuery(state.DataSetName, command.CommandText.Trim());
                 state.DataSource.Queries.Add(query);
             }

--- a/Import/ReportingServices/Expressions/ExpressionParser.cs
+++ b/Import/ReportingServices/Expressions/ExpressionParser.cs
@@ -203,6 +203,9 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Expressions {
                 case "len":
                     Assert(parameters.Count == 1, "Len");
                     return new FunctionOperator(FunctionOperatorType.Len, parameters[0]);
+                case "isnothing":
+                    Assert(parameters.Count == 1, "IsNothing");
+                    return new FunctionOperator(FunctionOperatorType.IsNullOrEmpty, parameters[0]);
             }
             if(allowUnrecognizedFunctions)
                 return new FunctionOperator(functionName, parameters);
@@ -244,6 +247,10 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Expressions {
                     return ProcessGlobals(property);
                 case "DateFormat":
                     return ProcessDateFormat(property);
+                case "String":
+                    if (property == "Empty")
+                        return new ConstantValue("");
+                    break;
             }
             if(string.Equals(property, "Value", StringComparison.CurrentCultureIgnoreCase))
                 return criteria;

--- a/Import/ReportingServices/Expressions/ExpressionParser.cs
+++ b/Import/ReportingServices/Expressions/ExpressionParser.cs
@@ -237,9 +237,9 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Expressions {
                 case "Globals":
                     return ProcessGlobals(property);
             }
-            if(property == "Value")
+            if(string.Equals(property, "Value", StringComparison.CurrentCultureIgnoreCase))
                 return criteria;
-            if(property == "ToString")
+            if(string.Equals(property, "ToString", StringComparison.CurrentCultureIgnoreCase))
                 return new FunctionOperator(FunctionOperatorType.ToStr, criteria);
             Fail(new FormattableString(Messages.ExpressionParser_Field_NotSupported_Format, property));
             return null;

--- a/Import/ReportingServices/Messages.cs
+++ b/Import/ReportingServices/Messages.cs
@@ -55,6 +55,7 @@
             ExpressionParser_BuiltInCollection_NotSupported_Format = "The '{0}!' collection could not be converted.",
             ExpressionParser_Field_NotSupported_Format = "The '.{0}' field could not be converted.",
             ExpressionParser_GlobalField_NotSupported_Format = "The 'Global.{0}' built-in field could not be converted.",
+            ExpressionParser_DateFormat_NotSupported_Format = "The 'DateFormat.{0}' built-in field could not be converted.",
             Expression_FilterOperatorNotSupported_Format = "Cannot convert the '{0}' filter operator.",
             Tablix_NotSupportedInsideTableCell_Format = "Tablix control '{0}' is not supported inside the table cell",
             DataSource_ConnectionParameters_Expression_NotSupported = "Expression value is not supported for connection parameters.",

--- a/Import/ReportingServices/Tablix/TablixMember.cs
+++ b/Import/ReportingServices/Tablix/TablixMember.cs
@@ -22,13 +22,14 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Tablix {
         static TablixMember Parse(XElement tablixMemberElement, string componentName, IReportingServicesConverter converter) {
             XNamespace ns = tablixMemberElement.GetDefaultNamespace();
             XElement group = tablixMemberElement.Element(ns + "Group");
+            var repeatOnNewPage = bool.Parse(tablixMemberElement.Element(ns + "RepeatOnNewPage")?.Value ?? "false");
             string groupName = group?.Attribute("Name").Value;
             HeaderModel header = HeaderModel.Parse(tablixMemberElement.Element(ns + "TablixHeader"), converter.UnitConverter);
             CriteriaOperator filterCriteria = Filter.ParseFilters(group?.Element(ns + "Filters"), componentName, converter);
             List<ExpressionMember> groupExpressions = ExpressionMember.Parse(group?.Element(ns + "GroupExpressions"), componentName, converter);
             List<SortExpressionMember> sortExpressions = SortExpressionMember.Parse(tablixMemberElement.Element(ns + "SortExpressions"), componentName, converter);
             List<TablixMember> members = ParseContainer(tablixMemberElement, componentName, converter);
-            return new TablixMember(groupName, header, filterCriteria, groupExpressions, sortExpressions, members);
+            return new TablixMember(groupName, header, filterCriteria, groupExpressions, sortExpressions, members, repeatOnNewPage);
         }
         public string GroupName { get; }
         public HeaderModel Header { get; }
@@ -36,13 +37,16 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Tablix {
         public ReadOnlyCollection<ExpressionMember> GroupExpressions { get; }
         public ReadOnlyCollection<SortExpressionMember> SortExpressions { get; }
         public ReadOnlyCollection<TablixMember> Members { get; }
-        public TablixMember(string groupName, HeaderModel header, CriteriaOperator filterCriteria, IList<ExpressionMember> groupExpressions, IList<SortExpressionMember> sortExpressions, IList<TablixMember> members) {
+        public bool RepeatOnNewPage { get; }
+
+        public TablixMember(string groupName, HeaderModel header, CriteriaOperator filterCriteria, IList<ExpressionMember> groupExpressions, IList<SortExpressionMember> sortExpressions, IList<TablixMember> members, bool repeatOnNewPage) {
             GroupName = groupName;
             Header = header;
             FilterCriteria = filterCriteria;
             GroupExpressions = new ReadOnlyCollection<ExpressionMember>(groupExpressions);
             SortExpressions = new ReadOnlyCollection<SortExpressionMember>(sortExpressions);
             Members = new ReadOnlyCollection<TablixMember>(members);
+            RepeatOnNewPage = repeatOnNewPage;
         }
 
         public bool TryGetSortExpressionMember(CriteriaOperator criteria, out SortExpressionMember sortExpression) {

--- a/Import/ReportingServices/Tablix/TablixToBandsConverter.cs
+++ b/Import/ReportingServices/Tablix/TablixToBandsConverter.cs
@@ -54,7 +54,8 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Tablix {
             if(groupBand == null) {
                 groupBand = new T {
                     Level = groupLevel,
-                    PrintAcrossBands = member.GetRowGroupPrintAcrossBands()
+                    PrintAcrossBands = member.GetRowGroupPrintAcrossBands(),
+                    RepeatEveryPage = member.RepeatOnNewPage
                 };
                 groupLevel += DetailBandExists ? 1 : -1;
                 InitializeNewBand(groupBand, member, report);

--- a/Import/ReportingServicesConverter.cs
+++ b/Import/ReportingServicesConverter.cs
@@ -63,6 +63,7 @@ namespace DevExpress.XtraReports.Import {
 
         protected override void ConvertInternal(string fileName) {
             reportFolder = Path.GetDirectoryName(fileName);
+            TargetReport.DisplayName = Path.GetFileNameWithoutExtension(fileName);
             using(FileStream fileStream = File.OpenRead(fileName)) {
                 XDocument rdlcDocument = SafeXml.CreateXDocument(fileStream);
                 xmlns = rdlcDocument.Root.GetDefaultNamespace();
@@ -149,7 +150,9 @@ namespace DevExpress.XtraReports.Import {
                     case "ReportTemplate":
                     case "InteractiveHeight":
                     case "InteractiveWidth":
+                        break;
                     case "Description":
+                        TargetReport.Tag = e.Value;
                         break;
                     default:
 #if DEBUG


### PR DESCRIPTION
Here are a few other improvements, that shouldn't cause any issues. I have a few other changes but will do those separately as they may need to be looked into further to not cause any breaking changes.

- Set the report Display Name to the name of the report (The file name in SSRS) and populate the Tag property with the report Description
- Support additional functions and fix issues with case sensitivity (maybe someone has edited RDL by hand)
  - IsNothing
  - String.Empty
  - CountDistinct (this has to be implemented a little weirdly, I can make any changes if you have feedback)
  - FormatDateTime
  - DateFormat.ShortDate
- Parse RepeatOnNewPage which is used to repeat header on each page, maps to RepeatEveryPage in DevExpress
- Use CustomSqlQuery directly when processing data sources, this fixes issues when a command might be like "EXEC Procedure @Param1 @Param2" that was not supported before