### PR TITLE
Fix issue with certain SQL queries

### DIFF
--- a/Import/ReportingServices/DataSources/DataSourceConverter.cs
+++ b/Import/ReportingServices/DataSources/DataSourceConverter.cs
@@ -315,10 +315,9 @@ namespace DevExpress.XtraReports.Import.ReportingServices.DataSources {
             if(query == null) {
                 var commandTypeEnum = (CommandType)Enum.Parse(typeof(CommandType), commandType);
                 var command = new SqlCommand() { CommandType = commandTypeEnum, CommandText = commandText };
-                query = DataSetToSqlDataSourceConverter.CreateSqlQuery(state.DataSetName, command);
-                if(query != null) {
-                    state.DataSource.Queries.Add(query);
-                }
+                SqlDataSource.DisableCustomQueryValidation = false;
+                query = new CustomSqlQuery(state.DataSetName, command.CommandText.Trim());
+                state.DataSource.Queries.Add(query);
             }
             return query;
         }

--- a/Import/ReportingServices/DataSources/DataSourceConverter.cs
+++ b/Import/ReportingServices/DataSources/DataSourceConverter.cs
@@ -315,7 +315,6 @@ namespace DevExpress.XtraReports.Import.ReportingServices.DataSources {
             if(query == null) {
                 var commandTypeEnum = (CommandType)Enum.Parse(typeof(CommandType), commandType);
                 var command = new SqlCommand() { CommandType = commandTypeEnum, CommandText = commandText };
-                SqlDataSource.DisableCustomQueryValidation = false;
                 query = new CustomSqlQuery(state.DataSetName, command.CommandText.Trim());
                 state.DataSource.Queries.Add(query);
             }

--- a/Import/ReportingServices/DataSources/DataSourceConverter.cs
+++ b/Import/ReportingServices/DataSources/DataSourceConverter.cs
@@ -310,12 +310,24 @@ namespace DevExpress.XtraReports.Import.ReportingServices.DataSources {
             });
         }
 
-        static SqlQuery GetOrAddQuery(DataSetConversionState state, string commandType, string commandText) {
+        SqlQuery GetOrAddQuery(DataSetConversionState state, string commandType, string commandText) {
             var query = state.DataSource.Queries.SingleOrDefault(x => x.Name == state.DataSetName);
             if(query == null) {
                 var commandTypeEnum = (CommandType)Enum.Parse(typeof(CommandType), commandType);
                 var command = new SqlCommand() { CommandType = commandTypeEnum, CommandText = commandText };
-                query = new CustomSqlQuery(state.DataSetName, command.CommandText.Trim());
+                if (converter.IgnoreQueryValidation && commandTypeEnum == CommandType.Text)
+                {
+                    query = new CustomSqlQuery(state.DataSetName, command.CommandText.Trim());
+                }
+                else
+                {
+                    query = DataSetToSqlDataSourceConverter.CreateSqlQuery(state.DataSetName, command);
+                }
+
+                if(query != null) {
+                    state.DataSource.Queries.Add(query);
+                }
+ 
                 state.DataSource.Queries.Add(query);
             }
             return query;

--- a/Import/ReportingServices/DataSources/DataSourceConverter.cs
+++ b/Import/ReportingServices/DataSources/DataSourceConverter.cs
@@ -327,8 +327,6 @@ namespace DevExpress.XtraReports.Import.ReportingServices.DataSources {
                 if(query != null) {
                     state.DataSource.Queries.Add(query);
                 }
- 
-                state.DataSource.Queries.Add(query);
             }
             return query;
         }

--- a/Import/ReportingServicesConverter.cs
+++ b/Import/ReportingServicesConverter.cs
@@ -42,6 +42,7 @@ namespace DevExpress.XtraReports.Import {
         };
 
         public UnrecognizedFunctionBehavior UnrecognizedFunctionBehavior { get; set; } = UnrecognizedFunctionBehavior.InsertWarning;
+        public bool IgnoreQueryValidation { get; set; } = false;
 
         UnitConverter unitConverter;
         string reportFolder;
@@ -1716,6 +1717,7 @@ namespace DevExpress.XtraReports.Import {
     interface IReportingServicesConverter {
         UnitConverter UnitConverter { get; }
         string ReportFolder { get; }
+        bool IgnoreQueryValidation { get; }
         void ProcessCommonControlProperties(XElement element, XRControl control, float yBodyOffset, bool throwException = true);
         void SetComponentName<T>(T component, string name = null);
         void ProcessReportItem(XElement reportItem, XRControl container, ref float yBodyOffset);

--- a/Program.cs
+++ b/Program.cs
@@ -95,13 +95,18 @@ namespace DevExpress.XtraReports.Import {
             if(extension == ".rdl" || extension == ".rdlc") {
                 Dictionary<string, string> ssrsProperties = CreateSubArg(argDictionary, "/ssrs");
                 string unrecognizedFunctionBehavior;
-                var crystalConverter = new ReportingServicesConverter();
+                var reportingServicesConverter = new ReportingServicesConverter();
                 if(ssrsProperties.TryGetValue("UnrecognizedFunctionBehavior", out unrecognizedFunctionBehavior)) {
-                    crystalConverter.UnrecognizedFunctionBehavior = string.Equals(unrecognizedFunctionBehavior, nameof(UnrecognizedFunctionBehavior.Ignore))
+                    reportingServicesConverter.UnrecognizedFunctionBehavior = string.Equals(unrecognizedFunctionBehavior, nameof(UnrecognizedFunctionBehavior.Ignore))
                         ? UnrecognizedFunctionBehavior.Ignore
                         : UnrecognizedFunctionBehavior.InsertWarning;
                 }
-                return crystalConverter;
+                string ignoreQueryValidation;
+                if(ssrsProperties.TryGetValue("IgnoreQueryValidation", out ignoreQueryValidation))
+                {
+                    reportingServicesConverter.IgnoreQueryValidation = bool.Parse(ignoreQueryValidation);
+                }
+                return reportingServicesConverter;
             }
             throw new ArgumentException($"File extension '{extension}' is not supported.");
         }


### PR DESCRIPTION
Use CustomSqlQuery directly when processing data sources, this fixes issues when a command might be like "EXEC Procedure @param1 @Param2" that was not supported before. Validation would fail on such commands and the query would return null.