### PR TITLE
Set Report DisplayName and populate Tag with Report description

### DIFF
--- a/Import/ReportingServicesConverter.cs
+++ b/Import/ReportingServicesConverter.cs
@@ -63,6 +63,7 @@ namespace DevExpress.XtraReports.Import {
 
         protected override void ConvertInternal(string fileName) {
             reportFolder = Path.GetDirectoryName(fileName);
+            TargetReport.DisplayName = Path.GetFileNameWithoutExtension(fileName);
             using(FileStream fileStream = File.OpenRead(fileName)) {
                 XDocument rdlcDocument = SafeXml.CreateXDocument(fileStream);
                 xmlns = rdlcDocument.Root.GetDefaultNamespace();
@@ -149,7 +150,9 @@ namespace DevExpress.XtraReports.Import {
                     case "ReportTemplate":
                     case "InteractiveHeight":
                     case "InteractiveWidth":
+                        break;
                     case "Description":
+                        TargetReport.Tag = e.Value;
                         break;
                     default:
 #if DEBUG


### PR DESCRIPTION
Set the report Display Name to the name of the report (The file name in SSRS) and populate the Tag property with the report Description. This way the information is not lost and can be used in DevExpress.

If there's a better property to use than Tag, I can change it, but nothing seemed obvious to me.