### PR TITLE
Additional function support and case sensitivity fixes

### DIFF
--- a/Import/ReportingServices/Expressions/ExpressionParser.cs
+++ b/Import/ReportingServices/Expressions/ExpressionParser.cs
@@ -203,6 +203,9 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Expressions {
                 case "len":
                     Assert(parameters.Count == 1, "Len");
                     return new FunctionOperator(FunctionOperatorType.Len, parameters[0]);
+                case "isnothing":
+                    Assert(parameters.Count == 1, "IsNothing");
+                    return new FunctionOperator(FunctionOperatorType.IsNullOrEmpty, parameters[0]);
             }
             if(allowUnrecognizedFunctions)
                 return new FunctionOperator(functionName, parameters);
@@ -244,6 +247,10 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Expressions {
                     return ProcessGlobals(property);
                 case "DateFormat":
                     return ProcessDateFormat(property);
+                case "String":
+                    if (property == "Empty")
+                        return new ConstantValue("");
+                    break;
             }
             if(string.Equals(property, "Value", StringComparison.CurrentCultureIgnoreCase))
                 return criteria;

--- a/Import/ReportingServices/Expressions/ExpressionParser.cs
+++ b/Import/ReportingServices/Expressions/ExpressionParser.cs
@@ -237,9 +237,9 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Expressions {
                 case "Globals":
                     return ProcessGlobals(property);
             }
-            if(property == "Value")
+            if(string.Equals(property, "Value", StringComparison.CurrentCultureIgnoreCase))
                 return criteria;
-            if(property == "ToString")
+            if(string.Equals(property, "ToString", StringComparison.CurrentCultureIgnoreCase))
                 return new FunctionOperator(FunctionOperatorType.ToStr, criteria);
             Fail(new FormattableString(Messages.ExpressionParser_Field_NotSupported_Format, property));
             return null;

--- a/Import/ReportingServices/Expressions/ExpressionParser.cs
+++ b/Import/ReportingServices/Expressions/ExpressionParser.cs
@@ -252,9 +252,9 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Expressions {
                         return new ConstantValue("");
                     break;
             }
-            if(string.Equals(property, "Value", StringComparison.CurrentCultureIgnoreCase))
+            if(string.Equals(property, "Value", StringComparison.InvariantCultureIgnoreCase))
                 return criteria;
-            if(string.Equals(property, "ToString", StringComparison.CurrentCultureIgnoreCase))
+            if(string.Equals(property, "ToString", StringComparison.InvariantCultureIgnoreCase))
                 return new FunctionOperator(FunctionOperatorType.ToStr, criteria);
             Fail(new FormattableString(Messages.ExpressionParser_Field_NotSupported_Format, property));
             return null;
@@ -278,7 +278,7 @@ namespace DevExpress.XtraReports.Import.ReportingServices.Expressions {
         CriteriaOperator ProcessDateFormat(string right) {
             switch(right) {
                 case "ShortDate":
-                    return new ConstantValue("{0:MM/dd/yyyy}");
+                    return new ConstantValue("{0:d}");
             }
             Fail(new FormattableString(Messages.ExpressionParser_DateFormat_NotSupported_Format, right));
             return null;

--- a/Import/ReportingServices/Messages.cs
+++ b/Import/ReportingServices/Messages.cs
@@ -55,6 +55,7 @@
             ExpressionParser_BuiltInCollection_NotSupported_Format = "The '{0}!' collection could not be converted.",
             ExpressionParser_Field_NotSupported_Format = "The '.{0}' field could not be converted.",
             ExpressionParser_GlobalField_NotSupported_Format = "The 'Global.{0}' built-in field could not be converted.",
+            ExpressionParser_DateFormat_NotSupported_Format = "The 'DateFormat.{0}' built-in field could not be converted.",
             Expression_FilterOperatorNotSupported_Format = "Cannot convert the '{0}' filter operator.",
             Tablix_NotSupportedInsideTableCell_Format = "Tablix control '{0}' is not supported inside the table cell",
             DataSource_ConnectionParameters_Expression_NotSupported = "Expression value is not supported for connection parameters.",


### PR DESCRIPTION
This adds support for additional functions and fixes issues with case sensitivity (for example maybe someone has edited RDL by hand)
  - IsNothing
  - String.Empty
  - CountDistinct (this has to be implemented a little weirdly, I can make any changes if you have feedback)
  - FormatDateTime
  - DateFormat.ShortDate